### PR TITLE
Avoid unpopular hnsearch links

### DIFF
--- a/backend/src/SlowNews/HackerNews.hs
+++ b/backend/src/SlowNews/HackerNews.hs
@@ -62,11 +62,8 @@ toLink query HNLink {hnlinkTitle, hnlinkUrl, hnlinkObjectID, hnlinkCreatedAtI} =
 fetch :: Site -> IO [Link]
 fetch (Site queryMaybe countMaybe) = do
   created_at_i <- show <$> (oneWeekAgo :: IO Integer)
-  putStrLn $ show (opts created_at_i)
   r <- asJSON =<< getWith (opts created_at_i) url :: IO (Response Body)
-  putStrLn $ "Returned" ++ show queryMaybe
   let results = r ^. responseBody & bodyChildren
-  putStrLn $ "Done" ++ show queryMaybe
   return $ toLink queryMaybe <$> results
   where
     url = "http://hn.algolia.com/api/v1/search"
@@ -80,8 +77,7 @@ fetch (Site queryMaybe countMaybe) = do
     opts c =
       defaults & params .~
       [ ("tags", "story")
-      , ("filters", T.pack $ "created_at_i>" ++ c)
-      , ("numericFilters", T.pack $ "num_comments>2")
+      , ("filters", T.pack $ "num_comments>2 AND created_at_i>" ++ c)
       , ("hitsPerPage", T.pack . show $ count)
       , ("query", T.pack . show $ query)
       ]

--- a/backend/src/SlowNews/HackerNews.hs
+++ b/backend/src/SlowNews/HackerNews.hs
@@ -37,7 +37,7 @@ instance FromJSON Body where
 
 data HNLink = HNLink
   { hnlinkTitle       :: Text
-  , hnlinkUrl         :: Text
+  , hnlinkUrl         :: Maybe Text
   , hnlinkObjectID    :: Text
   , hnlinkCreatedAtI  :: Int
   } deriving (Show, Eq)
@@ -52,8 +52,9 @@ instance FromJSON HNLink where
 
 toLink :: Maybe String -> HNLink -> Link
 toLink query HNLink {hnlinkTitle, hnlinkUrl, hnlinkObjectID, hnlinkCreatedAtI} =
-  Link hnlinkTitle hnlinkUrl metaURL hnlinkCreatedAtI (siteName query)
+  Link hnlinkTitle url metaURL hnlinkCreatedAtI (siteName query)
   where
+    url = fromMaybe metaURL hnlinkUrl
     metaURL = "https://news.ycombinator.com/item?id=" <> hnlinkObjectID
     siteName Nothing  = "hn"
     siteName (Just q) = T.pack $ "hn" <> "/" <> q


### PR DESCRIPTION
Filter for links with at least 3 comments. This is necessary for keywords search. 